### PR TITLE
Set module path  to standard module path convention

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/arobase-che/lazycut
+module github.com/emin-ozata/lazycut
 
 go 1.24.2
 

--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/arobase-che/lazycut/ui"
-	"github.com/arobase-che/lazycut/video"
+	"github.com/emin-ozata/lazycut/ui"
+	"github.com/emin-ozata/lazycut/video"
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"

--- a/ui/model.go
+++ b/ui/model.go
@@ -2,8 +2,8 @@ package ui
 
 import (
 	"fmt"
-	"github.com/arobase-che/lazycut/ui/panels"
-	"github.com/arobase-che/lazycut/video"
+	"github.com/emin-ozata/lazycut/ui/panels"
+	"github.com/emin-ozata/lazycut/video"
 	"strings"
 	"time"
 

--- a/ui/panels/preview.go
+++ b/ui/panels/preview.go
@@ -1,7 +1,7 @@
 package panels
 
 import (
-	"github.com/arobase-che/lazycut/video"
+	"github.com/emin-ozata/lazycut/video"
 
 	"github.com/charmbracelet/lipgloss"
 )

--- a/ui/panels/properties.go
+++ b/ui/panels/properties.go
@@ -2,7 +2,7 @@ package panels
 
 import (
 	"fmt"
-	"github.com/arobase-che/lazycut/video"
+	"github.com/emin-ozata/lazycut/video"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"

--- a/ui/panels/timeline.go
+++ b/ui/panels/timeline.go
@@ -2,7 +2,7 @@ package panels
 
 import (
 	"fmt"
-	"github.com/arobase-che/lazycut/video"
+	"github.com/emin-ozata/lazycut/video"
 	"strings"
 	"time"
 


### PR DESCRIPTION
Hello \o

Fix the module name to respect the the standard module path convention and them fix `go install`.  
So after this PR, `git install github.com/emin-ozata/lazycut@latest` should just works (ie: Install `lazycut` in `$GOPATH/.bin`).

See <https://go.dev/ref/mod#module-path>

> A module path should describe both what *the module does and where to find it*. Typically, a module path consists of **a repository root path**, a directory within the repository (usually empty), and a major version suffix (only for major version 2 or higher).

Emphasis  is mine.