### PR TITLE
feat: remap section shortcuts for consistency

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -266,11 +266,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 
-		case "X":
+		case "x":
 			m.player.RemoveLastSection()
 			return m, nil
 
+		case "X":
+			m.player.ClearSections()
+			return m, nil
+
 		case "p":
+			if n := len(m.player.Sections); n > 0 {
+				last := m.player.Sections[n-1]
+				m.previewQueue = []video.Section{last}
+				m.previewQueueIdx = 0
+				m.player.Seek(last.In)
+				m.previewMode = true
+				m.player.Play()
+			}
+			return m, nil
+
+		case "P":
 			var queue []video.Section
 			if m.player.Trim.InPoint != nil && m.player.Trim.OutPoint != nil {
 				queue = []video.Section{{In: *m.player.Trim.InPoint, Out: *m.player.Trim.OutPoint}}
@@ -282,17 +297,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.previewQueue = queue
 				m.previewQueueIdx = 0
 				m.player.Seek(queue[0].In)
-				m.previewMode = true
-				m.player.Play()
-			}
-			return m, nil
-
-		case "P":
-			if n := len(m.player.Sections); n > 0 {
-				last := m.player.Sections[n-1]
-				m.previewQueue = []video.Section{last}
-				m.previewQueueIdx = 0
-				m.player.Seek(last.In)
 				m.previewMode = true
 				m.player.Play()
 			}
@@ -545,9 +549,10 @@ func (m Model) renderHelpModal() string {
 	trim := sectionStyle.Render("TRIM") + "\n" +
 		kd("i", "Set in-point") + "\n" +
 		kd("o", "Set out-point") + "\n" +
-		kd("X", "Remove last section") + "\n" +
-		kd("p", "Preview all sections") + "\n" +
-		kd("P", "Preview last section") + "\n" +
+		kd("x", "Remove last section") + "\n" +
+		kd("X", "Remove all sections") + "\n" +
+		kd("p", "Preview last section") + "\n" +
+		kd("P", "Preview all sections") + "\n" +
 		kd("d / Esc", "Clear selection") + "\n" +
 		kd("Enter", "Export")
 

--- a/ui/panels/timeline.go
+++ b/ui/panels/timeline.go
@@ -208,21 +208,22 @@ func (t *Timeline) footerHelp(width int) string {
 	if t.exportStatus != "" {
 		result = " " + t.exportStatus
 	} else if len(sections) > 0 && trim.InPoint == nil {
-		remove := "remove section"
+		removeLabel := "remove"
+		previewLabel := "preview"
 		if len(sections) > 1 {
-			remove = "remove last section"
-		}
-		preview := "preview"
-		if len(sections) > 1 {
-			preview = "preview all"
+			removeLabel = "remove last"
+			previewLabel = "preview last"
 		}
 		hints := " " + badge +
 			kd("Enter", "export", true) + sep +
 			kd("i", "in", false) + "  " + kd("o", "out", false) + sep +
-			kd("X", remove, false) + sep +
-			kd("p", preview, false)
+			kd("x", removeLabel, false)
 		if len(sections) > 1 {
-			hints += "  " + kd("P", "preview last", false)
+			hints += "  " + kd("X", "remove all", false)
+		}
+		hints += sep + kd("p", previewLabel, false)
+		if len(sections) > 1 {
+			hints += "  " + kd("P", "preview all", false)
 		}
 		result = hints + sep +
 			kd("h/l", "±1s", false) + "  " + kd("H/L", "±5s", false) + sep +


### PR DESCRIPTION
## Summary

- `p` now previews the **last** section; `P` previews **all** sections (previously swapped)
- `x` removes the last section; `X` removes **all** sections (`x` is new, `X` repurposed)
- Footer hints group removes together and previews together (no `·` separator within each group)
- `X` (remove all) and `P` (preview all) hints only appear when there are multiple sections
- When only one section exists, labels read "remove" and "preview" instead of "remove last" / "preview last"

## Test plan

- [x] Set a single section: footer shows `x remove · p preview` only
- [x] Set multiple sections: footer shows `x remove last  X remove all · p preview last  P preview all`
- [x] `p` seeks to and plays only the last section
- [x] `P` plays all sections sequentially
- [x] `x` removes the last section (count decreases by 1)
- [x] `X` clears all sections at once
- [x] `?` help modal shows all four keys with correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)